### PR TITLE
Ensure correct minimum height for small events

### DIFF
--- a/JZCalendarWeekView/JZWeekViewFlowLayout.swift
+++ b/JZCalendarWeekView/JZWeekViewFlowLayout.swift
@@ -320,7 +320,13 @@ open class JZWeekViewFlowLayout: UICollectionViewFlowLayout {
                     endMinuteY = CGFloat(itemEndTime.minute!) * minuteHeight
                 }
                 else {
-                    endMinuteY = CGFloat(itemStartTime.minute!+15) * minuteHeight
+                    // Calculate new end time by adding 15 mins to startDate
+                    let newEndTime = Calendar.current.dateComponents([.day, .hour, .minute], from: startDate.addingTimeInterval(60*15))
+                    if newEndTime.minute == 0 {
+                        endMinuteY = CGFloat(59) * minuteHeight
+                    } else {
+                        endMinuteY = CGFloat(newEndTime.minute!) * minuteHeight
+                    }
                 }
             }
             else {


### PR DESCRIPTION
Changed logic so that a date object adds 15 mins to the start time and then use that value as the end minute for small event cells

![image](https://user-images.githubusercontent.com/16906503/85185072-a3e3d780-b24f-11ea-917b-bfb8de9d8f05.png)
